### PR TITLE
Update tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "id-16",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Create random id's and numbers in base 16!",
   "main": "index.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -6,9 +6,15 @@ var id16 = require('../index')
 
 /* Setup the tests
  * ============================================================================= */
-vows.describe('generate-ID').addBatch({
+vows.describe('id-16').addBatch({
   'An ID': {
     topic: id16,
+    'is a base 16 (hexadecimal) string': function (result) {
+      /* This regular expression should represent base16 somehow
+       * Check (https://www.sitepoint.com/community/t/how-to-check-if-string-is-hexadecimal) */
+      var regularExpression = /[0-9A-Fa-f]{6}/g
+      assert(regularExpression.test(result))
+    },
     'has a default length of 8': function (result) {
       assert.deepEqual(result.length, 8, `ID has unexpected length.`)
     }
@@ -17,6 +23,12 @@ vows.describe('generate-ID').addBatch({
     topic: id16.generator,
     'returns a function': function (result) {
       assert.deepEqual(typeof result, 'function', `id16.generator() does not return a function.`)
+    },
+    'creates a base 16 (hexadecimal) string': function (result) {
+      /* This regular expression should represent base16 somehow
+       * Check (https://www.sitepoint.com/community/t/how-to-check-if-string-is-hexadecimal) */
+      var regularExpression = /[0-9A-Fa-f]{6}/g
+      assert(regularExpression.test(result()))
     },
     "creates unique ID's": function (result) {
       assert.notEqual(result(), result(), `The generator created two identical ID's`)

--- a/test/travis-ci.sh
+++ b/test/travis-ci.sh
@@ -14,5 +14,5 @@ echo '  [✓] vows installed.'
 
 # Run our test file
 echo '  [*] Running our tests (./tests/test.js)'
-vows ./test/test.js
-echo '[✓] Test completed.'
+vows ./test/test.js --spec
+echo '  [✓] Test completed.'


### PR DESCRIPTION
Tests are now run using the `—spec` flag. This results in better
readable printout.

Added a new test to the file. This test checks if the numbers created
by the generator and the base function are indeed base16 (hexadecimal).